### PR TITLE
systems: add Vulkan flags for Pi4/Pi5

### DIFF
--- a/scriptmodules/emulators/dolphin.sh
+++ b/scriptmodules/emulators/dolphin.sh
@@ -54,6 +54,8 @@ function depends_dolphin() {
     # if using the latest version, add SDL2 as dependency, since it's mandatory
     [[ "$(_get_commit_dolphin)" == "" ]] && depends+=(libsdl2-dev)
 
+    # install Vulkan drivers when needed
+    isPlatform "vulkan" && depends+=(mesa-vulkan-drivers)
     getDepends "${depends[@]}"
 }
 

--- a/scriptmodules/emulators/ppsspp.sh
+++ b/scriptmodules/emulators/ppsspp.sh
@@ -31,6 +31,7 @@ function depends_ppsspp() {
     isPlatform "videocore" && depends+=(libraspberrypi-dev)
     isPlatform "mesa" && depends+=(libgles2-mesa-dev)
     isPlatform "vero4k" && depends+=(vero3-userland-dev-osmc)
+    isPlatform "vulkan" && depends+=(mesa-vulkan-drivers)
     getDepends "${depends[@]}"
 }
 

--- a/scriptmodules/supplementary/sdl2.sh
+++ b/scriptmodules/supplementary/sdl2.sh
@@ -49,6 +49,7 @@ function _list_depends_sdl2() {
     isPlatform "gl" || isPlatform "rpi" && depends+=(libgl1-mesa-dev libglu1-mesa-dev)
     isPlatform "kms" || isPlatform "rpi" && depends+=(libdrm-dev libgbm-dev)
     isPlatform "x11" && depends+=(libpulse-dev libwayland-dev)
+    isPlatform "vulkan" && depends+=(libvulkan-dev)
 
     echo "${depends[@]}"
 }

--- a/scriptmodules/system.sh
+++ b/scriptmodules/system.sh
@@ -368,6 +368,10 @@ function get_rpi_video() {
             fi
         fi
         [[ "$__has_dispmanx" -eq 1 ]] && __platform_flags+=(dispmanx)
+        # Pi4/5 have Vulkan working under KMS on Debian 12 (bookworm) or newer
+        if (isPlatform "rpi4" || isPlatform "rpi5")  && [[ "$__os_debian_ver" -ge 12 ]]; then
+            __platform_flags+=(vulkan)
+        fi
     else
         __platform_flags+=(videocore)
         if ! isPlatform "aarm64"; then


### PR DESCRIPTION
Added Vulkan as supported renderer for Pi4/Pi5 when running on RaspiOS 12 Bookworm. Technically the support was added in Bullseye for Pi4, but it was only available under X11.

Notes:
 - most emulators include the Vulkan headers, so there's no need to add `libvulkan-dev` as a dependency.
 - not all emulators will run with Vulkan from KMS/DRM - `ppsspp`/`dolphin` can use it under x11/wayland, while `retroarch` runs with the`vulkan` video driver on KMS/DRM.
 - switching RetroArch to use the `vulkan` renderer needs to include the installation/configuration of SLANG shaders, which is not handled at the moment.